### PR TITLE
Added support for executing a script from file or from stdin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 .DS_Store
 *.log
 .vscode/
+.vs/

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,8 @@ go 1.18
 require (
 	github.com/google/uuid v1.3.0
 	github.com/schollz/progressbar/v3 v3.13.0
-)
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
+	)
 
 require (
 	github.com/mattn/go-runewidth v0.0.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213/go.mod h1:vNUNkEQ1e29fT/6vq2aBdFsgNPmy8qMdSay1npru+Sw=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWVwUuU=
 github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=

--- a/main.go
+++ b/main.go
@@ -34,6 +34,8 @@ func printHelp() {
 	print("  info path                          show info about <path>")
 	print("  sha1 path                          get SHA1 hash for <path>")
 	print("  sha256 path                        get SHA256 hash for <path>")
+	print("  script path                        evaluate <path> as a script")
+	print("  script -                           execute commands from stdin")
 	print("  help                               show help")
 	print("  migrate configPath                 migrate from old (< v0.6) config at <configPath> to current config")
 	print("  version                            show version")

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-var AppVersion = "v0.8.0"
+var AppVersion = "v0.8.1"


### PR DESCRIPTION
Sometimes several operations will be executed in close succession. To avoid the seemingly costly operation of initializing the programs connection to OneDrive, the possibility to execute several commands in one go seems nice to have.
The pull request adds the following commands:

`script <scriptfile>  `  
reads and executes a script from file

`script -    `       
reads and executes commands from stdin. This may both be used for piping scripts into the program, or using it as a simple OneDrive shell.