### PR TITLE
Add cd/pwd commands and relative path support

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/virtualzone/onedrive-uploader/sdk"
@@ -33,6 +34,8 @@ var (
 		"info":     {Fn: cmdInfo, MinArgs: 1, InitSecretStore: true, RequireConfig: true},
 		"sha1":     {Fn: cmdSHA1, MinArgs: 1, InitSecretStore: true, RequireConfig: true},
 		"sha256":   {Fn: cmdSHA256, MinArgs: 1, InitSecretStore: true, RequireConfig: true},
+		"cd":       {Fn: cmdCD, MinArgs: 1, InitSecretStore: true, RequireConfig: true},
+		"pwd":      {Fn: cmdPwd, MinArgs: 0, InitSecretStore: false, RequireConfig: true},
 		"migrate":  {Fn: cmdMigrateConfig, MinArgs: 1, InitSecretStore: false, RequireConfig: false},
 		"version":  {Fn: cmdVersion, MinArgs: 0, InitSecretStore: false, RequireConfig: false},
 	}
@@ -118,8 +121,9 @@ func cmdLogin(client *sdk.Client, renderer *OutputRenderer, args []string) {
 }
 
 func cmdCreateDir(client *sdk.Client, renderer *OutputRenderer, args []string) {
+	targetPath := resolvePath(args[0], client.Config.CurrentDirectory)
 	renderer.initSpinner("Creating directory...")
-	err := client.CreateDir(args[0])
+	err := client.CreateDir(targetPath)
 	renderer.stopSpinner()
 	if err != nil {
 		logError("Could not create folder: " + err.Error())
@@ -129,7 +133,7 @@ func cmdCreateDir(client *sdk.Client, renderer *OutputRenderer, args []string) {
 }
 
 func cmdUpload(client *sdk.Client, renderer *OutputRenderer, args []string) {
-	targetFolder := args[len(args)-1]
+	targetFolder := resolvePath(args[len(args)-1], client.Config.CurrentDirectory)
 	sourceFiles := args[:len(args)-1]
 	numFiles := 0
 	for _, sourceFile := range sourceFiles {
@@ -171,6 +175,7 @@ func cmdUpload(client *sdk.Client, renderer *OutputRenderer, args []string) {
 }
 
 func cmdDownload(client *sdk.Client, renderer *OutputRenderer, args []string) {
+	sourcePath := resolvePath(args[0], client.Config.CurrentDirectory)
 	done := false
 	go func() {
 		var fileStat fs.FileInfo = nil
@@ -193,7 +198,7 @@ func cmdDownload(client *sdk.Client, renderer *OutputRenderer, args []string) {
 	go func() {
 		done = <-client.ChannelTransferFinish
 	}()
-	err := client.Download(args[0], args[1])
+	err := client.Download(sourcePath, args[1])
 	if err != nil {
 		logError("Could not download file: " + err.Error())
 		return
@@ -202,8 +207,9 @@ func cmdDownload(client *sdk.Client, renderer *OutputRenderer, args []string) {
 }
 
 func cmdDelete(client *sdk.Client, renderer *OutputRenderer, args []string) {
+	targetPath := resolvePath(args[0], client.Config.CurrentDirectory)
 	renderer.initSpinner("Deleting...")
-	err := client.Delete(args[0])
+	err := client.Delete(targetPath)
 	renderer.stopSpinner()
 	if err != nil {
 		logError("Could not delete: " + err.Error())
@@ -213,8 +219,9 @@ func cmdDelete(client *sdk.Client, renderer *OutputRenderer, args []string) {
 }
 
 func cmdList(client *sdk.Client, renderer *OutputRenderer, args []string) {
+	targetPath := resolvePath(args[0], client.Config.CurrentDirectory)
 	renderer.initSpinner("Retrieving directory listing...")
-	list, err := client.List(args[0])
+	list, err := client.List(targetPath)
 	renderer.stopSpinner()
 	if err != nil {
 		logError("Could not list: " + err.Error())
@@ -230,8 +237,9 @@ func cmdList(client *sdk.Client, renderer *OutputRenderer, args []string) {
 }
 
 func cmdInfo(client *sdk.Client, renderer *OutputRenderer, args []string) {
+	targetPath := resolvePath(args[0], client.Config.CurrentDirectory)
 	renderer.initSpinner("Retrieving information...")
-	item, err := client.Info(args[0])
+	item, err := client.Info(targetPath)
 	renderer.stopSpinner()
 	if err != nil {
 		logError("Could not get info: " + err.Error())
@@ -254,8 +262,9 @@ func cmdInfo(client *sdk.Client, renderer *OutputRenderer, args []string) {
 }
 
 func cmdSHA1(client *sdk.Client, renderer *OutputRenderer, args []string) {
+	targetPath := resolvePath(args[0], client.Config.CurrentDirectory)
 	renderer.initSpinner("Retrieving SHA1 hash...")
-	item, err := client.Info(args[0])
+	item, err := client.Info(targetPath)
 	renderer.stopSpinner()
 	if err != nil {
 		logError("Could not get info: " + err.Error())
@@ -265,14 +274,47 @@ func cmdSHA1(client *sdk.Client, renderer *OutputRenderer, args []string) {
 }
 
 func cmdSHA256(client *sdk.Client, renderer *OutputRenderer, args []string) {
+	targetPath := resolvePath(args[0], client.Config.CurrentDirectory)
 	renderer.initSpinner("Retrieving SHA256 hash...")
-	item, err := client.Info(args[0])
+	item, err := client.Info(targetPath)
 	renderer.stopSpinner()
 	if err != nil {
 		logError("Could not get info: " + err.Error())
 		return
 	}
 	print(item.File.Hashes.SHA256)
+}
+
+func cmdCD(client *sdk.Client, renderer *OutputRenderer, args []string) {
+	targetPath := resolvePath(args[0], client.Config.CurrentDirectory)
+
+	// Check if the path exists and is a folder
+	renderer.initSpinner("Checking directory...")
+	item, err := client.Info(targetPath)
+	renderer.stopSpinner()
+	if err != nil {
+		logError("Could not access directory: " + err.Error())
+		return
+	}
+
+	// Check if it's a folder
+	if item.Type != sdk.DriveItemTypeFolder {
+		logError("Path is not a directory")
+		return
+	}
+
+	// Update current directory in config and save
+	client.Config.CurrentDirectory = targetPath
+	if err := client.Config.Write(); err != nil {
+		logError("Could not save configuration: " + err.Error())
+		return
+	}
+
+	log("Changed directory to: " + targetPath)
+}
+
+func cmdPwd(client *sdk.Client, renderer *OutputRenderer, args []string) {
+	print(client.Config.CurrentDirectory)
 }
 
 func cmdVersion(client *sdk.Client, renderer *OutputRenderer, args []string) {
@@ -284,4 +326,19 @@ func cutString(s string, maxLen int) string {
 		return s
 	}
 	return s[:maxLen]
+}
+
+// resolvePath converts relative paths (starting with .) to absolute paths using current directory from config
+func resolvePath(path string, currentDir string) string {
+	if strings.HasPrefix(path, ".") {
+		// Replace . with current directory
+		if currentDir == "/" {
+			// If current directory is /, just remove the .
+			return strings.TrimPrefix(path, ".")
+		} else {
+			// Replace . with current directory
+			return currentDir + strings.TrimPrefix(path, ".")
+		}
+	}
+	return path
 }

--- a/main.go
+++ b/main.go
@@ -34,6 +34,8 @@ func printHelp() {
 	print("  info path                          show info about <path>")
 	print("  sha1 path                          get SHA1 hash for <path>")
 	print("  sha256 path                        get SHA256 hash for <path>")
+	print("  cd path                            change current directory to <path>")
+	print("  pwd                                show current directory")
 	print("  help                               show help")
 	print("  migrate configPath                 migrate from old (< v0.6) config at <configPath> to current config")
 	print("  version                            show version")

--- a/sdk/config.go
+++ b/sdk/config.go
@@ -8,16 +8,17 @@ import (
 )
 
 type Config struct {
-	ConfigFilePath string    `json:"-"`
-	ClientID       string    `json:"client_id"`
-	ClientSecret   string    `json:"client_secret"`
-	Scopes         []string  `json:"scopes"`
-	RedirectURL    string    `json:"redirect_uri"`
-	Root           string    `json:"root"`
-	AccessToken    string    `json:"access_token"`
-	RefreshToken   string    `json:"refresh_token"`
-	Expiry         time.Time `json:"expiry"`
-	SecretStore    string    `json:"secret_store,omitempty"`
+	ConfigFilePath   string    `json:"-"`
+	ClientID         string    `json:"client_id"`
+	ClientSecret     string    `json:"client_secret"`
+	Scopes           []string  `json:"scopes"`
+	RedirectURL      string    `json:"redirect_uri"`
+	Root             string    `json:"root"`
+	AccessToken      string    `json:"access_token"`
+	RefreshToken     string    `json:"refresh_token"`
+	Expiry           time.Time `json:"expiry"`
+	SecretStore      string    `json:"secret_store,omitempty"`
+	CurrentDirectory string    `json:"current_directory,omitempty"`
 }
 
 func ReadConfigData(data []byte) (*Config, error) {
@@ -28,6 +29,9 @@ func ReadConfigData(data []byte) (*Config, error) {
 	config.Root = strings.TrimSuffix(config.Root, "/")
 	if !strings.HasPrefix(config.Root, "/") {
 		config.Root = "/" + config.Root
+	}
+	if config.CurrentDirectory == "" {
+		config.CurrentDirectory = "/"
 	}
 	return &config, nil
 }


### PR DESCRIPTION
## Add

* cd <path> - change current directory (validates path exists and is a folder)
* pwd - show current directory

Support for relative paths with . prefix in all commands (mkdir, ls, rm, etc.)

## Example

```sh
./onedrive-uploader cd /Documents
./onedrive-uploader pwd
./onedrive-uploader ls .
./onedrive-uploader mkdir ./NewFolder  
```