### PR TITLE
fix(config): correct config read error handling

### DIFF
--- a/sdk/config.go
+++ b/sdk/config.go
@@ -38,8 +38,11 @@ func ReadConfig(filename string) (*Config, error) {
 		return nil, err
 	}
 	config, err := ReadConfigData(data)
+	if err != nil {
+		return nil, err
+	}
 	config.ConfigFilePath = filename
-	return config, err
+	return config, nil
 }
 
 func (config *Config) Write() error {


### PR DESCRIPTION
This PR fixes a nil pointer dereference in `sdk.ReadConfig` that could cause the CLI to panic when the config file exists but contains invalid JSON (or otherwise fails to parse).
